### PR TITLE
Add time parameter to measure task duration

### DIFF
--- a/DOGFILE_REFERENCE.md
+++ b/DOGFILE_REFERENCE.md
@@ -58,6 +58,14 @@ Multiline scripts are supported.
     done
 ```
 
+### time
+
+Measure how much time it takes to run the task. Duration will be printed after the task output. Boolean parameter, the default value is `false`.
+
+```yml
+  time: true
+```
+
 ### type
 
 The default execution type is `sh` on UNIX-like operating systems and `cmd` on Windows, but other execution types will be supported.

--- a/Dogfile.yml
+++ b/Dogfile.yml
@@ -1,5 +1,6 @@
 - task: build
   description: Build dog binary
+  time: true
   run: |
     [ -d bin ] || mkdir bin
     go get -u ./...

--- a/dog/types.go
+++ b/dog/types.go
@@ -12,7 +12,7 @@ import (
 type Task struct {
 	Name        string `json:"task,omitempty"`
 	Description string `json:"description,omitempty"`
-	Duration    bool   `json:"duration,omitempty"`
+	Time        bool   `json:"time,omitempty"`
 	Run         string `json:"run,omitempty"`
 	Path        string `json:"path,omitempty"`
 }

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/xsb/dog/dog"
 )
@@ -26,6 +27,8 @@ func NewDefaultExecutor(cmd string) *Default {
 // Exec executes the created tmp script and writes the output to the writer.
 func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 	var err error
+	var startTime time.Time
+
 	if err = t.ToDisk(); err != nil {
 		return err
 	}
@@ -50,6 +53,10 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 		return err
 	}
 
+	if t.Time {
+		startTime = time.Now()
+	}
+
 	if err = cmd.Start(); err != nil {
 		return err
 	}
@@ -59,6 +66,11 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 		return err
 	}
 	w.Write([]byte("=== Task " + t.Name + " finished ===\n"))
+
+	if t.Time {
+		duration := time.Now().Sub(startTime)
+		w.Write([]byte(duration.String() + "\n"))
+	}
 
 	return nil
 }


### PR DESCRIPTION
This code was removed in the first executors proposal. I know it's a bit crappy but it works™. How could we improve this?

Ideally the executor should return the time so whoever is calling it would decide if print it or not.

Closes #4 