### PR TITLE
Status code and code cleanup

### DIFF
--- a/dog/task.go
+++ b/dog/task.go
@@ -10,10 +10,12 @@ import (
 
 // Task is a representation of a dogfile task
 type Task struct {
-	Name        string `json:"task,omitempty"`
+	Name        string `json:"task"`
 	Description string `json:"description,omitempty"`
-	Run         string `json:"run,omitempty"`
-	Path        string `json:"path,omitempty"`
+	Time        bool   `json:"time,omitempty"`
+	Run         string `json:"run"`
+	Executor    string `json:"executor"`
+	Path        string `json:"-"`
 }
 
 // TaskMap is a map in which the key is a task name and the value is a Task object

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -3,10 +3,11 @@
 package def
 
 import (
-	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/xsb/dog/dog"
 )
@@ -25,22 +26,10 @@ func NewDefaultExecutor(cmd string) *Default {
 
 // Exec executes the created tmp script and writes the output to the writer.
 func (def *Default) Exec(t *dog.Task, w io.Writer) error {
-	var err error
 
-	if err = t.ToDisk(); err != nil {
+	if err := t.ToDisk(); err != nil {
 		return err
 	}
-
-	defer func() {
-		// Remove temporary script in goroutine to not block by IO ops.
-		go func() {
-			err := os.Remove(t.Path)
-			if err != nil {
-				w.Write([]byte(err.Error() + "\n"))
-			}
-			w.Write([]byte(" - " + t.Name + " finished with status code\n"))
-		}()
-	}()
 
 	binary, err := exec.LookPath(def.cmd)
 	if err != nil {
@@ -48,46 +37,31 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 	}
 
 	cmd := exec.Command(binary, t.Path)
-	if err = gatherCmdOutput(cmd, w); err != nil {
-		return err
-	}
 
-	if err = cmd.Start(); err != nil {
-		return err
-	}
 	w.Write([]byte(" - " + t.Name + " started\n"))
 
-	if err = cmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func gatherCmdOutput(cmd *exec.Cmd, w io.Writer) error {
-	stdoutReader, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	stderrReader, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	stdoutScanner := bufio.NewScanner(stdoutReader)
-	stderrScanner := bufio.NewScanner(stderrReader)
-	go func() {
-		for stdoutScanner.Scan() {
-			w.Write([]byte(stdoutScanner.Text() + "\n"))
+	statusCode := 0
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); !ok {
+				// For unknown error status codes set it to 1
+				statusCode = 1
+			} else {
+				statusCode = waitStatus.ExitStatus()
+			}
 		}
-	}()
+		w.Write(output)
+		w.Write([]byte("\n" + err.Error() + "\n"))
+	} else {
+		w.Write(output)
+	}
 
-	go func() {
-		for stderrScanner.Scan() {
-			w.Write([]byte(stderrScanner.Text() + "\n"))
-		}
-	}()
+	msg := fmt.Sprintf(" - %s finished with status code %d\n", t.Name, statusCode)
+	w.Write([]byte(msg))
+
+	if err := os.Remove(t.Path); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -54,7 +54,7 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 	if err = cmd.Start(); err != nil {
 		return err
 	}
-	w.Write([]byte("=== Task " + t.Name + " started ===\n"))
+	w.Write([]byte(" - " + t.Name + " started\n"))
 
 	if err = cmd.Wait(); err != nil {
 		return err

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -79,15 +79,13 @@ func gatherCmdOutput(cmd *exec.Cmd, w io.Writer) error {
 	stderrScanner := bufio.NewScanner(stderrReader)
 	go func() {
 		for stdoutScanner.Scan() {
-			msg := "\033[34m --= MSG: " + stdoutScanner.Text() + "\n\033[0m"
-			w.Write([]byte(msg))
+			w.Write([]byte(stdoutScanner.Text() + "\n"))
 		}
 	}()
 
 	go func() {
 		for stderrScanner.Scan() {
-			msg := "\033[31m --= ERR: " + stderrScanner.Text() + "\n\033[0m"
-			w.Write([]byte(msg))
+			w.Write([]byte(stderrScanner.Text() + "\n"))
 		}
 	}()
 

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -38,6 +38,7 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 			if err != nil {
 				w.Write([]byte(err.Error() + "\n"))
 			}
+			w.Write([]byte(" - " + t.Name + " finished with status code\n"))
 		}()
 	}()
 
@@ -59,7 +60,6 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 	if err = cmd.Wait(); err != nil {
 		return err
 	}
-	w.Write([]byte("=== Task " + t.Name + " finished ===\n"))
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -49,8 +49,13 @@ func main() {
 
 		if _, ok := tm[taskName]; ok {
 			task := tm[taskName]
-			e := dog.GetExecutor("system")
-			e.Exec(&task, os.Stdout)
+			e := dog.GetExecutor(task.Executor)
+			if e == nil {
+				e = dog.GetExecutor("system")
+			}
+			if err := e.Exec(&task, os.Stdout); err != nil {
+				fmt.Println(err)
+			}
 		} else {
 			fmt.Println("No task named " + taskName)
 		}


### PR DESCRIPTION
This simplifies a lot the logic in executor, also provides logic for retrieving status code (unix and windows compatible). Concurrency overcomplexity removed in favor of more simple implementation, we can add task level parallelism later if needed, better than intratask things, like we were doing (output gathering, file removal...).

This closes #28 

@xsb 