### PR TITLE
Remove time

### DIFF
--- a/DOGFILE_SPEC.md
+++ b/DOGFILE_SPEC.md
@@ -58,14 +58,6 @@ Multiline scripts are supported.
     done
 ```
 
-### time
-
-Measure how much time it takes to run the task. Duration will be printed after the task output. Boolean parameter, the default value is `false`.
-
-```yml
-  time: true
-```
-
 ### type
 
 The default execution type is `sh` on UNIX-like operating systems and `cmd` on Windows, but other execution types will be supported.

--- a/Dogfile.yml
+++ b/Dogfile.yml
@@ -1,6 +1,5 @@
 - task: build
   description: Build dog binary
-  time: true
   run: |
     [ -d bin ] || mkdir bin
     go get -u ./...

--- a/dog/types.go
+++ b/dog/types.go
@@ -12,7 +12,6 @@ import (
 type Task struct {
 	Name        string `json:"task,omitempty"`
 	Description string `json:"description,omitempty"`
-	Time        bool   `json:"time,omitempty"`
 	Run         string `json:"run,omitempty"`
 	Path        string `json:"path,omitempty"`
 }

--- a/executors/def/def.go
+++ b/executors/def/def.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/xsb/dog/dog"
 )
@@ -27,7 +26,6 @@ func NewDefaultExecutor(cmd string) *Default {
 // Exec executes the created tmp script and writes the output to the writer.
 func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 	var err error
-	var startTime time.Time
 
 	if err = t.ToDisk(); err != nil {
 		return err
@@ -53,10 +51,6 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 		return err
 	}
 
-	if t.Time {
-		startTime = time.Now()
-	}
-
 	if err = cmd.Start(); err != nil {
 		return err
 	}
@@ -66,11 +60,6 @@ func (def *Default) Exec(t *dog.Task, w io.Writer) error {
 		return err
 	}
 	w.Write([]byte("=== Task " + t.Name + " finished ===\n"))
-
-	if t.Time {
-		duration := time.Now().Sub(startTime)
-		w.Write([]byte(duration.String() + "\n"))
-	}
 
 	return nil
 }


### PR DESCRIPTION
> Time is a tool to measure the day, it doesn't go backwards, only one way!

This closes #33.

I have removed the code entirely as there wasn't that much code to begin with. We could bring this back in the future as `--time` or some sort of `--verbose` mode.